### PR TITLE
Add setup-dotnet action for .NET 8.x and 9.x support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,11 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: | 
+            8.x
+            9.x
       - uses: dotnet/nbgv@master
         with:
           setAllVars: true


### PR DESCRIPTION
The `actions/setup-dotnet@v4` action has been added to the `main.yml` workflow file to support .NET versions 8.x and 9.x. This setup step is placed before the existing `dotnet/nbgv@master` action. The `fetch-depth: 0` configuration for the `actions/checkout@v2` action remains unchanged.