### PR TITLE
Fix tenant id regex for net7+

### DIFF
--- a/src/Serilog.Sinks.Loki/Internal/LokiHttpClientExtensions.cs
+++ b/src/Serilog.Sinks.Loki/Internal/LokiHttpClientExtensions.cs
@@ -14,7 +14,7 @@ namespace Serilog.Sinks.Loki.Internal
         private const string _tenantHeader = "X-Scope-OrgID";
 
 #if NET7_0_OR_GREATER
-        [GeneratedRegex("@\"^[a-zA-Z0-9]*$\"")]
+        [GeneratedRegex("^[a-zA-Z0-9]*$")]
         private static partial Regex TenantIdValueRegex();
 #else
 


### PR DESCRIPTION
Found a small problem while testing with using a tenant id.
This fixes the tenant id regex for net7+