### PR TITLE
Fixed ScalarValue boxed cast exception for short, ushort and byte

### DIFF
--- a/src/Serilog.Sinks.Loki/Internal/ScalarValueFormattingExtensions.cs
+++ b/src/Serilog.Sinks.Loki/Internal/ScalarValueFormattingExtensions.cs
@@ -1,4 +1,4 @@
-﻿// This file is part of the project licensed under the MIT License.
+// This file is part of the project licensed under the MIT License.
 // See the LICENSE file in the project root for more information.
 
 
@@ -23,10 +23,12 @@ namespace Serilog.Sinks.Loki.Internal
 
             switch (value)
             {
-                case int:
                 case short:
                 case ushort:
                 case byte:
+                    writer.WriteNumberValue(Convert.ToInt32(value));
+                    break;
+                case int:
                     writer.WriteNumberValue((int)value);
                     break;
                 case uint:


### PR DESCRIPTION
Writing `int` values work great:
<img width="1339" height="639" alt="image" src="https://github.com/user-attachments/assets/8a2c54f4-5726-433a-9f19-0031ce749850" />

But writing `short`, `ushort`, `byte` results in:
<img width="1455" height="658" alt="image" src="https://github.com/user-attachments/assets/6ad8adeb-6f33-4a01-a398-35952d09c739" />

`ScalarValue.Value` is of type `object?`.  

<img width="263" height="30" alt="image" src="https://github.com/user-attachments/assets/b62c2137-9351-4e64-919c-b6f47ec7cf1b" />


When boxed it can't be casted to `int` anymore. 
```
using System; 
	
//((int)((object)(int)5)) // ok 
//((int)((object)(short)5)) // error 
//((int)((object)(ushort)5)) // error 
//((int)((object)(byte)5)) // error 
	
// fix:
Convert.ToInt32((object)(byte)5) // ok 
```